### PR TITLE
Add conda environment and setup Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_script:
 script:
   - cd dsc/
   - dsc benchmark.dsc -h
-  - dsc benchmark.dsc
+  - dsc benchmark.dsc --truncate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+python:
+  - "3.6"
+
+install:
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - travis_retry conda env create --quiet --file environment.yaml
+
+before_script:
+  - source activate dsc-log-fold-change
+  - conda list
+  - dsc --version
+
+script:
+  - cd dsc/
+  - dsc benchmark.dsc -h
+  - dsc benchmark.dsc --truncate

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_script:
 script:
   - cd dsc/
   - dsc benchmark.dsc -h
-  - dsc benchmark.dsc --truncate
+  - dsc benchmark.dsc

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
-  - travis_retry conda env create --quiet --file environment.yaml
+  - travis_retry conda env create --file environment.yaml
 
 before_script:
   - source activate dsc-log-fold-change

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dsc-log-fold-change
 
-[![Travis-CI Build Status](https://travis-ci.org/jdblischak/dsc-log-fold-change.svg?branch=master)](https://travis-ci.org/jdblischak/dsc-log-fold-change)
+[![Travis-CI Build Status](https://travis-ci.org/stephenslab/dsc-log-fold-change.svg?branch=master)](https://travis-ci.org/stephenslab/dsc-log-fold-change)
 
 This is (or will be) a Dynamic Statistical Comparison
 to estimating (or testing) the "log-fold-change" in mean between

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dsc-log-fold-change
 
+[![Travis-CI Build Status](https://travis-ci.org/jdblischak/dsc-log-fold-change.svg?branch=master)](https://travis-ci.org/jdblischak/dsc-log-fold-change)
+
 This is (or will be) a Dynamic Statistical Comparison
 to estimating (or testing) the "log-fold-change" in mean between
 two groups from count data.

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,28 @@
+name: dsc-log-fold-change
+channels:
+- conda-forge
+- bioconda
+- defaults
+- jdblischak
+dependencies:
+# DSC
+- conda-forge::dsc=0.3.3
+- conda-forge::r-devtools
+- jdblischak::r-dscrutils
+# Benchmark
+- bioconda::bioconductor-biocparallel
+- bioconda::bioconductor-edger
+- bioconda::bioconductor-deseq2
+- bioconda::bioconductor-limma
+- bioconda::bioconductor-mast
+- bioconda::bioconductor-zinbwave
+- conda-forge::r-dplyr
+- conda-forge::r-ggplot2
+- conda-forge::r-rcolorbrewer
+# workflowr
+- conda-forge::r-knitr
+- conda-forge::r-rmarkdown
+- conda-forge::r-workflowr
+# Utility
+- conda-forge::jupyter
+- jdblischak::sos-notebook


### PR DESCRIPTION
@jhsiao999 @stephens999 I was able to successfully run `dsc benchmark.dsc --truncate` on my local machine and also on Travis (on my fork).

https://travis-ci.org/jdblischak/dsc-log-fold-change/builds/489121969

I was unable to run the workflowr analyses because they contain absolute paths.

@pcarbo Could you please add me as a collaborator on this repo so that I can activate Travis?