### PR TITLE
Update CI (again)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,13 @@ jobs:
             conda config --add channels conda-forge
             conda info -a
             # Install conda packages
-            conda env create --file environment.yaml
-            conda list -n dsc-log-fold-change
+            conda install --file requirements/conda-forge \
+                          --file requirements/bioconda \
+                          --file requirements/jdblischak
+            conda list
       - run:
           name: Run DSC
           command: |
-            source activate dsc-log-fold-change
             cd dsc/
             dsc --version
             dsc benchmark.dsc -h

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: python
+python:
+  - "3.6"
+
+install:
+  - wget https://repo.continuum.io/miniconda/Miniconda3-4.3.27.1-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes
+  - conda config --set changeps1 no
+  - conda config --set auto_update_conda no
+  - conda config --add channels jdblischak
+  - conda config --add channels defaults
+  - conda config --add channels bioconda
+  - conda config --add channels conda-forge
+  - conda info -a
+  # Install conda packages
+  - travis_retry conda env create --file environment.yaml
+
+before_script:
+  - source activate dsc-log-fold-change
+  - conda list
+  - dsc --version
+
+script:
+  - cd dsc/
+  - dsc benchmark.dsc -h
+  - dsc benchmark.dsc --truncate

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ install:
   - conda config --add channels conda-forge
   - conda info -a
   # Install conda packages
-  - travis_retry conda env create --file environment.yaml
+  - travis_retry conda install --file=requirements/conda-forge --file=requirements/bioconda --file=requirements/jdblischak
 
 before_script:
-  - source activate dsc-log-fold-change
   - conda list
   - dsc --version
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,34 @@ Output:
 
 List methods we might want to use...
 
+# Installation
+
+We manage package installation using conda. Aftering installing conda, you have
+two options for installing the dependencies:
+
+1. Create a new environment with `conda-env`:
+    ```
+    conda env create --file environment.yaml
+    source activate dsc-log-fold-change
+    ```
+1. Directory install with `conda install`:
+    ```
+    conda config --add channels jdblischak
+    conda config --add channels defaults
+    conda config --add channels bioconda
+    conda config --add channels conda-forge
+    conda install --file requirements/conda-forge \
+                  --file requirements/bioconda \
+                  --file requirements/jdblischak
+    ```
+
+The advantage of the first option is convenience. It creates an environment and
+installs packages from specific channels, all in one step. The advantage of the
+second step is that it is faster and more robust.
+
+If you need to add a new package for the benchmark, please add it to both
+`environment.yaml` and to one of the files in `requirements/`.
+
 # Run DSC
 
 The main DSC file is `benchmarks.dsc`. To see what is available:

--- a/requirements/bioconda
+++ b/requirements/bioconda
@@ -1,0 +1,7 @@
+bioconductor-biocparallel
+bioconductor-edger
+bioconductor-deseq2
+bioconductor-limma
+bioconductor-mast
+bioconductor-qvalue
+bioconductor-zinbwave

--- a/requirements/bioconda
+++ b/requirements/bioconda
@@ -3,5 +3,6 @@ bioconductor-edger
 bioconductor-deseq2
 bioconductor-limma
 bioconductor-mast
+bioconductor-sva
 bioconductor-qvalue
 bioconductor-zinbwave

--- a/requirements/conda-forge
+++ b/requirements/conda-forge
@@ -1,0 +1,10 @@
+dsc=0.3.3
+jupyter
+r-devtools
+r-dplyr
+r-ggplot2
+r-knitr
+r-proc
+r-rcolorbrewer
+r-rmarkdown
+r-workflowr

--- a/requirements/jdblischak
+++ b/requirements/jdblischak
@@ -1,0 +1,3 @@
+r-dscrutils
+r-seqgendiff
+sos-notebook


### PR DESCRIPTION
A follow-up to #14. Using `conda install` appears to be more robust than `conda env create` on both CircleCI and Travis. The main downside is that now we have to maintain the list of dependencies in `environment.yaml` and in `requirements/`. I also added some installation instructions.